### PR TITLE
Update lokinet-0.9.11-r1.ebuild - cmake

### DIFF
--- a/net-vpn/lokinet/lokinet-0.9.11-r1.ebuild
+++ b/net-vpn/lokinet/lokinet-0.9.11-r1.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="amd64 ~x86 ~arm64 ~arm ~mips ~mips64 ~ppc64"
 IUSE="cpu_flags_x86_avx2 coverage daemon debug embedded hive jemalloc liblokinet netns shadow testnet test"
 
 DEPEND="dev-vcs/git
-    dev-util/cmake
+    dev-build/cmake
     >=dev-libs/libuv-1.27
     dev-libs/openssl
     dev-libs/spdlog


### PR DESCRIPTION
dev-build/cmake
 is what the cmake package is named in the main gentoo tree. Trying to make it installable but. Is this Overlay even maintained?
 
 This barely fixes anything but i guess i should contribute this at least since i am not going to fix this enough to make it work.